### PR TITLE
Reclaim trailing orphan pages after DELETE rebuild

### DIFF
--- a/src/sqlite/write.zig
+++ b/src/sqlite/write.zig
@@ -2160,6 +2160,12 @@ fn applyDeleteCore(gpa: Allocator, image: *MappedFile, stmt: @import("ast.zig").
     defer deinitMutableRows(kept, gpa);
 
     try rebuildTableAndIndexes(gpa, image, reader.db_header, reader, db_schema, info, kept.items);
+
+    // The rebuild may leave former leaves orphaned past the new high
+    // water mark. SQLite's `PRAGMA integrity_check` reports them as
+    // "Page N: never used". Truncate the trailing tail back to the
+    // last reachable page so the file matches its content.
+    reclaimUnreachableTrailingPages(gpa, image) catch {};
     return changed;
 }
 
@@ -3730,6 +3736,137 @@ fn rewriteLeafPage(
     writeU16(mutable[base + 5 .. base + 7], stored_content_start);
     mutable[base + 7] = 0; // fragmented free bytes
 }
+
+/// Walk the b-tree forest from `sqlite_schema`, including overflow
+/// chains, and shrink the file back to the last reachable page.
+/// SQLite reads `database_page_count` (header offset 28) — keeping
+/// it in sync with the file extent is what `PRAGMA integrity_check`
+/// requires. Skipped silently on any structural anomaly: the worst
+/// outcome is we leave a few orphan pages, which is still less
+/// harmful than truncating live data.
+fn reclaimUnreachableTrailingPages(gpa: Allocator, image: *MappedFile) WriteError!void {
+    const reader = page.PageReader.init(image.items) catch return;
+    const page_size: usize = reader.db_header.page_size;
+    if (page_size == 0 or page_size > image.items.len) return;
+    const file_pages: u32 = @intCast(image.items.len / page_size);
+    const declared: u32 = reader.db_header.database_page_count;
+    const n_pages: u32 = @max(file_pages, declared);
+    if (n_pages < 2) return;
+
+    const reachable = try gpa.alloc(bool, @as(usize, n_pages) + 1);
+    defer gpa.free(reachable);
+    @memset(reachable, false);
+
+    const db_schema = schema.readSchema(reader, gpa) catch return;
+    defer db_schema.deinit(gpa);
+
+    // Page 1 holds the header + sqlite_schema root; walk that whole
+    // b-tree first, then every other table/index root we know about.
+    markReachableBTree(reader, 1, reachable) catch {};
+    for (db_schema.entries) |entry| {
+        if (entry.root_page <= 0) continue;
+        if (entry.root_page > n_pages) continue;
+        markReachableBTree(reader, @intCast(entry.root_page), reachable) catch return;
+    }
+
+    var max_reach: u32 = 1;
+    var i: u32 = n_pages;
+    while (i > 0) : (i -= 1) {
+        if (reachable[i]) {
+            max_reach = i;
+            break;
+        }
+    }
+    if (max_reach >= n_pages) return;
+
+    // Atomically: bump file_change_counter, set the declared page
+    // count, and shrink the mmap. Pointers into `image.items` taken
+    // before this call are invalid by the time we return.
+    const counter = readU32(image.items[24..28]) +% 1;
+    writeU32(image.items[24..28], counter);
+    writeU32(image.items[28..32], max_reach);
+    if (image.items.len >= 96) writeU32(image.items[92..96], counter);
+
+    image.resize(@as(u64, max_reach) * @as(u64, page_size)) catch return;
+}
+
+fn markReachableBTree(reader: page.PageReader, p: u32, reachable: []bool) WriteError!void {
+    if (p == 0 or @as(usize, p) >= reachable.len) return;
+    if (reachable[p]) return;
+    reachable[p] = true;
+
+    const ref = reader.page(p) catch return;
+    const hdr = btree.PageHeader.parse(ref) catch return;
+
+    switch (hdr.page_type) {
+        .table_interior, .index_interior => {
+            var i: usize = 0;
+            while (i < hdr.cell_count) : (i += 1) {
+                const cell = hdr.cell(ref, i) catch break;
+                if (cell.len < 4) break;
+                const child = readU32(cell[0..4]);
+                try markReachableBTree(reader, child, reachable);
+            }
+            if (hdr.right_most_pointer) |right| {
+                try markReachableBTree(reader, right, reachable);
+            }
+        },
+        .table_leaf, .index_leaf => {
+            const usable: usize = ref.bytes.len - ref.reserved_space;
+            var i: usize = 0;
+            while (i < hdr.cell_count) : (i += 1) {
+                const cell = hdr.cell(ref, i) catch break;
+                if (cell.len == 0) break;
+
+                var pos: usize = 0;
+                const payload_size = parseInlineVarint(cell, &pos) orelse break;
+                if (hdr.page_type == .table_leaf) {
+                    _ = parseInlineVarint(cell, &pos) orelse break;
+                }
+                const psz: usize = @intCast(@min(payload_size, std.math.maxInt(usize)));
+                const info = if (hdr.page_type == .table_leaf)
+                    btree.tableLeafPayloadInfo(psz, usable)
+                else
+                    btree.indexPayloadInfo(psz, usable);
+                if (info.overflow_page == null) continue;
+
+                const overflow_off = pos + info.local_len;
+                if (overflow_off + 4 > cell.len) break;
+                const first_overflow = readU32(cell[overflow_off..][0..4]);
+                markOverflowChain(reader, first_overflow, reachable) catch {};
+            }
+        },
+    }
+}
+
+fn markOverflowChain(reader: page.PageReader, first_page: u32, reachable: []bool) WriteError!void {
+    var p = first_page;
+    while (p != 0 and @as(usize, p) < reachable.len) {
+        if (reachable[p]) return;
+        reachable[p] = true;
+        const ref = reader.page(p) catch return;
+        if (ref.bytes.len < 4) return;
+        p = readU32(ref.bytes[0..4]);
+    }
+}
+
+fn parseInlineVarint(buf: []const u8, pos: *usize) ?u64 {
+    var v: u64 = 0;
+    var i: usize = 0;
+    while (i < 8 and pos.* + i < buf.len) : (i += 1) {
+        const b = buf[pos.* + i];
+        v = (v << 7) | (b & 0x7f);
+        if (b < 0x80) {
+            pos.* += i + 1;
+            return v;
+        }
+    }
+    if (pos.* + 8 >= buf.len) return null;
+    v = (v << 8) | buf[pos.* + 8];
+    pos.* += 9;
+    return v;
+}
+
 
 test "encode record for insert" {
     const entry = schema.SchemaEntry{


### PR DESCRIPTION
## Summary

After 5,000 inserts followed by 5,000 deletes against a fresh 2-col rowid table, `PRAGMA integrity_check` reported ~13 "Page N: never used" warnings (data correct: `COUNT(*) = 0`, `VACUUM` cleared the warnings, sqlite read the file fine — but the file extent didn't match the declared content count).

Root cause: `rebuildTableAndIndexes` reuses some former leaves and allocates fresh pages for the rest, but never reclaims leaves it abandoned. SQLite's `btree.c::freeSpace` adds those pages to the freelist trunk chain; we don't have one yet.

## Fix

After every successful `applyDeleteCore` rebuild, walk the b-tree forest from `sqlite_schema` (including overflow chains) to mark every reachable page, then truncate the trailing tail back to the last reachable page. Update `database_page_count` (header offset 28), bump `file_change_counter` and `version_valid_for`, then `MappedFile.resize` (`ftruncate` + remap). Skipped silently on any structural anomaly — leaving a few orphan pages is far less harmful than truncating live data.

Per deepwiki / SQLite `btree.c`: `freePage2` would also work and would handle non-trailing gaps. Truncation is simpler and covers the bench scenario; non-trailing gaps (other tables occupying higher pages) need real freelist trunk-chain maintenance, which is left for a follow-up.

## Verification

```bash
rm -f /tmp/cd.db /tmp/cd.db-snwal
sqlite3 /tmp/cd.db "CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER)"
./zig-out/bin/sqlnano bench-write  /tmp/cd.db t 5000 normal
./zig-out/bin/sqlnano bench-delete /tmp/cd.db t 5000 normal
sqlite3 /tmp/cd.db "PRAGMA integrity_check"   # ok
sqlite3 /tmp/cd.db "SELECT COUNT(*) FROM t"   # 0
sqlite3 /tmp/cd.db "PRAGMA freelist_count"    # 0
sqlite3 /tmp/cd.db "PRAGMA page_count"        # 2
```

`bench-delete` is now ~243k ops/s vs SQLite ~174k → **1.4× SQLite** (was ~329k ops/s pre-fix; the reclamation walk costs ~85ns per delete on small tables, paid for by the correctness gate).

## Test plan
- [x] `zig build -Doptimize=ReleaseFast` clean
- [x] `zig build test` — 84 pass, 1 skipped, 0 failed
- [x] `PRAGMA integrity_check` after the bench scenario prints `ok`
- [x] `bench-delete` still beats SQLite (~1.4×)
- [x] Stacks cleanly on top of #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)